### PR TITLE
Add example for logging in with Meteor 'resume' tokens.

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,6 @@ server.userId; // undefined, we are not logged in
 
 let resumeToken = 'N50Gmknk__geP63YD9pHKdl07b8XXxNGpB_cz5Lte4d'
 
-// you must pass password and at least one of username or email
 let userAuth = await server.login({
   resume: 'N50Gmknk__geP63YD9pHKdl07b8XXxNGpB_cz5Lte4d'
 });

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ server.userId; // undefined, we are not logged in
 let resumeToken = 'N50Gmknk__geP63YD9pHKdl07b8XXxNGpB_cz5Lte4d'
 
 let userAuth = await server.login({
-  resume: 'N50Gmknk__geP63YD9pHKdl07b8XXxNGpB_cz5Lte4d'
+  resume: resumeToken,
 });
 
 // userAuth will be something like this

--- a/README.md
+++ b/README.md
@@ -74,6 +74,28 @@ server.userId; // now equals to 'd6PqCAKk2QZeqZHWy'
 server.token; // now equals to 'N50Gmknk__geP63YD9pHKdl07b8XXxNGpB_cz5Lte4d'
 ```
 
+#### Example for session tokens
+
+```javascript
+server.userId; // undefined, we are not logged in
+
+let resumeToken = 'N50Gmknk__geP63YD9pHKdl07b8XXxNGpB_cz5Lte4d'
+
+// you must pass password and at least one of username or email
+let userAuth = await server.login({
+  resume: 'N50Gmknk__geP63YD9pHKdl07b8XXxNGpB_cz5Lte4d'
+});
+
+// userAuth will be something like this
+// { id: 'd6PqCAKk2QZeqZHWy',
+//   token: 'N50Gmknk__geP63YD9pHKdl07b8XXxNGpB_cz5Lte4d',
+//   tokenExpires: { '$date': 1548525528846 },
+//   type: 'resume' }
+
+server.userId; // now equals to 'd6PqCAKk2QZeqZHWy'
+server.token; // now equals to 'N50Gmknk__geP63YD9pHKdl07b8XXxNGpB_cz5Lte4d'
+```
+
 ### simpleDDP.logout()
 
 Call this method to logout.


### PR DESCRIPTION
I keep having to dig through the Accounts package to find a reference point for how to resume sessions using an auth token instead of the traditional username/password approach,

This pull request adds an example for logging in with a resume token. This should hopefully save the people a few minutes. 🙌